### PR TITLE
Add usage message and other stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+giffy
+===
+
+Tiny wrapper around ffmpeg to create gifs quickly.
+
+### Usage
+
+Clone this repo, add its folder to your `PATH`, then:
+
+```
+$ giffy [input video] [output gif]
+```

--- a/giffy
+++ b/giffy
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -o nounset
+
 giffy() {
   input=$1
   output=$2

--- a/giffy
+++ b/giffy
@@ -4,6 +4,11 @@ set -o nounset
 set -o errexit
 
 giffy() {
+  if [[ "$#" -ne 2 ]]; then
+    echo -e "Usage:\n$ ${FUNCNAME[0]} [input video] [output gif]"
+    exit 1
+  fi
+
   input=$1
   output=$2
 

--- a/giffy
+++ b/giffy
@@ -12,28 +12,28 @@ giffy() {
   input=$1
   output=$2
 
-   echo "Creating pallete"
-   _createPallete "$input"
+  echo "Creating pallete"
+  _createPallete "$input"
 
-   echo "Creating gif..."
-   _convertToGif "$input" "$output"
+  echo "Creating gif..."
+  _convertToGif "$input" "$output"
 
-   echo "Cleaning up..."
-   _cleanUp
+  echo "Cleaning up..."
+  _cleanUp
 }
 
 _createPallete() {
-   createPallete="ffmpeg -i $1 -vf palettegen tmp_pallete.png"
-    eval "$createPallete" > /dev/null
+  createPallete="ffmpeg -i $1 -vf palettegen tmp_pallete.png"
+  eval "$createPallete" > /dev/null
 }
 
 _convertToGif() {
-   convertToGif="ffmpeg -i $1 -i tmp_pallete.png -r 10 $2"
-    eval "$convertToGif" > /dev/null
+  convertToGif="ffmpeg -i $1 -i tmp_pallete.png -r 10 $2"
+  eval "$convertToGif" > /dev/null
 }
 
 _cleanUp() {
-   eval "rm tmp_pallete.png"
+  eval "rm tmp_pallete.png"
 }
 
 giffy "$@"

--- a/giffy
+++ b/giffy
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -o nounset
+set -o errexit
 
 giffy() {
   input=$1

--- a/giffy
+++ b/giffy
@@ -27,3 +27,5 @@ _convertToGif() {
 _cleanUp() {
    eval "rm tmp_pallete.png"
 }
+
+giffy "$@"

--- a/giffy
+++ b/giffy
@@ -8,10 +8,10 @@ giffy() {
   output=$2
 
    echo "Creating pallete"
-   _createPallete $input
+   _createPallete "$input"
 
    echo "Creating gif..."
-   _convertToGif $input $output
+   _convertToGif "$input" "$output"
 
    echo "Cleaning up..."
    _cleanUp
@@ -19,12 +19,12 @@ giffy() {
 
 _createPallete() {
    createPallete="ffmpeg -i $1 -vf palettegen tmp_pallete.png"
-    eval $createPallete > /dev/null
+    eval "$createPallete" > /dev/null
 }
 
 _convertToGif() {
    convertToGif="ffmpeg -i $1 -i tmp_pallete.png -r 10 $2"
-    eval $convertToGif > /dev/null
+    eval "$convertToGif" > /dev/null
 }
 
 _cleanUp() {


### PR DESCRIPTION
Summary of changes:
* Makes script executable and require it to be added to `PATH`. Having to source the script in your shell is not ideal because auxiliary functions like `_createPallete` become global;
* Fail script when unbound variables are found;
* Immediately stop script if a command fails;
* Use double quotes to prevent globbing and word splitting ([SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086));
* Add usage to script and readme file (fixes #1).